### PR TITLE
Bug-fix: activateConsumptionReport should give 201 not 204 response.

### DIFF
--- a/python/lib/rt_m1_client/client.py
+++ b/python/lib/rt_m1_client/client.py
@@ -558,6 +558,8 @@ class M1Client:
             ret['ConsumptionReportingConfiguration'] = ConsumptionReportingConfiguration.fromJSON(result['body'])
             return ret
         elif result['status_code'] in [201, 204]:
+            # Versions of the Application Function prior to v1.4.1 returned an incorrect 204 to indicate success, since AF v1.4.1
+            # the return code was corrected to 201 as per TS 26.512 Clause 4.3.8.2. We accept both for backward compatibility.
             return True
         self.__default_response(result)
         return None

--- a/python/lib/rt_m1_client/client.py
+++ b/python/lib/rt_m1_client/client.py
@@ -557,7 +557,7 @@ class M1Client:
             ret: ConsumptionReportingConfigurationResponse = self.__tag_and_date(result)
             ret['ConsumptionReportingConfiguration'] = ConsumptionReportingConfiguration.fromJSON(result['body'])
             return ret
-        elif result['status_code'] == 204:
+        elif result['status_code'] in [201, 204]:
             return True
         self.__default_response(result)
         return None


### PR DESCRIPTION
Fix issue with the wrong status code return for creating a consumption reporting configuration.

Treat 204 like 201 for compatibility with versions of the Application Function before v1.4.1.

This is the Application Provider counterpart to pull request  5G-MAG/rt-5gms-application-function#160.