### PR TITLE
Uplift of 5GMS AF to TS 26.512 v17.9.1

### DIFF
--- a/python/src/rt_m1_apps/m1_client.py
+++ b/python/src/rt_m1_apps/m1_client.py
@@ -61,9 +61,9 @@ from typing import Optional, Union
 import cryptography
 import OpenSSL
 
-installed_packages_dir = '@python_packages_dir@'
-if os.path.isdir(installed_packages_dir) and installed_packages_dir not in sys.path:
-    sys.path.append(installed_packages_dir)
+#installed_packages_dir = '@python_packages_dir@'
+#if os.path.isdir(installed_packages_dir) and installed_packages_dir not in sys.path:
+#    sys.path.append(installed_packages_dir)
 
 from rt_m1_client.client import M1Client, ProvisioningSessionResponse, ContentProtocolsResponse, ServerCertificateSigningRequestResponse, ServerCertificateResponse, ContentHostingConfigurationResponse, ConsumptionReportingConfigurationResponse, PolicyTemplateResponse, MetricsReportingConfigurationResponse
 from rt_m1_client.types import PROVISIONING_SESSION_TYPE_DOWNLINK, PROVISIONING_SESSION_TYPE_UPLINK, ContentHostingConfiguration, ConsumptionReportingConfiguration, PolicyTemplate, MetricsReportingConfiguration

--- a/python/src/rt_m1_apps/m1_session.py
+++ b/python/src/rt_m1_apps/m1_session.py
@@ -171,9 +171,9 @@ from typing import Tuple, List, Optional
 import json
 import OpenSSL
 
-installed_packages_dir = '@python_packages_dir@'
-if os.path.isdir(installed_packages_dir) and installed_packages_dir not in sys.path:
-    sys.path.append(installed_packages_dir)
+#installed_packages_dir = '@python_packages_dir@'
+#if os.path.isdir(installed_packages_dir) and installed_packages_dir not in sys.path:
+#    sys.path.append(installed_packages_dir)
 
 from rt_m1_client.session import M1Session
 from rt_m1_client.exceptions import M1Error

--- a/python/src/rt_m1_apps/msaf_configuration.py
+++ b/python/src/rt_m1_apps/msaf_configuration.py
@@ -224,9 +224,9 @@ import os.path
 import sys
 from typing import List, Optional
 
-installed_packages_dir = '@python_packages_dir@'
-if os.path.isdir(installed_packages_dir) and installed_packages_dir not in sys.path:
-    sys.path.append(installed_packages_dir)
+#installed_packages_dir = '@python_packages_dir@'
+#if os.path.isdir(installed_packages_dir) and installed_packages_dir not in sys.path:
+#    sys.path.append(installed_packages_dir)
 
 from rt_m1_client.session import M1Session
 from rt_m1_client.exceptions import M1Error


### PR DESCRIPTION
PR 5G-MAG/rt-5gms-application-function#164 implements an uplift of the 5GMS AF to be inline with TS 26.512 v17.9.1. As part of this uplift the *MetricsReportingConfiguration.sliceScope* field was added. This PR adds the ability to set and update the *sliceScope*s on a metrics configuration via the interface at reference point M1. To this end an extra `--slice` command line optional argument has been added to the metrics configuration management commands of the `m1-session` tool.

This PR also contains a bug fix for issue #53 which keeps the in memory cache consistent for updates to certificates.

This PR will only work properly against a 5GMS AF compiled with the changes in PRs 5G-MAG/rt-common-shared#39 and 5G-MAG/rt-5gms-application-function#164.