### PR TITLE
Fix async syntax issues

### DIFF
--- a/python/lib/rt_media_configuration/media_configuration.py
+++ b/python/lib/rt_media_configuration/media_configuration.py
@@ -128,7 +128,7 @@ configuration with the 5GMS AF.
         try:
             await self.__loadModelFromDatastore()
             m1_imp = await M1SessionImporter(self.__m1_session)
-            m1_imp.import_to(self)
+            await m1_imp.import_to(self)
         except Exception as exc:
             self.__log.error(f"Failed to restore model: {exc}")
             return False
@@ -218,7 +218,7 @@ configuration with the 5GMS AF.
         to_add = list(other.__model['sessions'].values())
         for session in self.__model['sessions'].values():
             for o_session in to_add:
-                if await session.shallow_eq(o_session):
+                if session.shallow_eq(o_session):
                     have += [(session, o_session)]
                     to_add.remove(o_session)
                     break

--- a/python/lib/rt_media_configuration/media_session.py
+++ b/python/lib/rt_media_configuration/media_session.py
@@ -105,7 +105,7 @@ This class models a 3GPP TS 26.512 ProvisioningSession. The ProvisioningSession 
             return False
         return self.__dynamic_policies == other.__dynamic_policies
 
-    async def shallow_eq(self, other: "MediaSession") -> bool:
+    def shallow_eq(self, other: "MediaSession") -> bool:
         if self.__is_downlink != other.__is_downlink:
             return False
         if self.__external_app_id != other.__external_app_id:


### PR DESCRIPTION
Fix a couple of small issues found with the *async* syntax in the `rt_media_configuration` Python module.