### PR TITLE
M1Session: Ensure correct cache state after update and delete operations

### DIFF
--- a/python/lib/rt_m1_client/session.py
+++ b/python/lib/rt_m1_client/session.py
@@ -362,7 +362,12 @@ class M1Session:
         if provisioning_session_id not in self.__provisioning_sessions:
             return None
         await self.__connect()
-        return await self.__m1_client.uploadServerCertificate(provisioning_session_id, certificate_id, pem)
+        result: Optional[bool] = await self.__m1_client.uploadServerCertificate(provisioning_session_id, certificate_id, pem)
+        if result is not None and result:
+            ps = await self.__getProvisioningSessionCache(provisioning_session_id)
+            if ps is not None and 'certificates' in ps and certificate_id in ps['certificates']:
+                del ps['certificates'][certificate_id]
+        return result
 
     async def certificateDelete(self, provisioning_session_id: ResourceId, certificate_id: ResourceId) -> Optional[bool]:
         '''Delete the server certificate in a provisioning session
@@ -434,7 +439,30 @@ class M1Session:
         if provisioning_session not in self.__provisioning_sessions:
             return False
         await self.__connect()
-        return await self.__m1_client.updateContentHostingConfiguration(provisioning_session, chc)
+        result: bool = await self.__m1_client.updateContentHostingConfiguration(provisioning_session, chc)
+        # Clear the cache if update successful
+        if result:
+            ps = await self.__getProvisioningSessionCache(provisioning_session)
+            if ps is not None and ps['content-hosting-configuration'] is not None:
+                ps['content-hosting-configuration'] = None
+        return result
+
+    async def contentHostingConfigurationDelete(self, provisioning_session: ResourceId) -> bool:
+        '''Delete the `ContentHostingConfiguration` for a provisioning session
+
+        :param provisioning_session: The provisioning session id of the provisioning session to delete the
+                                     `ContentHostingConfiguration` from.
+        :return: ``True`` if the `ContentHostingConfiguration` was successfully delete or ``False`` if the deletion failed
+        '''
+        if provisioning_session not in self.__provisioning_sessions:
+            return False
+        await self.__connect()
+        result: bool = await self.__m1_client.destroyContentHostingConfiguration(provisioning_session)
+        if result:
+            ps = await self.__getProvisioningSessionCache(provisioning_session)
+            if ps is not None and ps['content-hosting-configuration'] is not None:
+                ps['content-hosting-configuration'] = None
+        return result
 
     # ConsumptionReportingConfiguration methods
 
@@ -487,7 +515,13 @@ class M1Session:
         if provisioning_session not in self.__provisioning_sessions:
             return False
         await self.__connect()
-        return await self.__m1_client.updateConsumptionReportingConfiguration(provisioning_session, crc)
+        result: bool = await self.__m1_client.updateConsumptionReportingConfiguration(provisioning_session, crc)
+        # Clear cache if update successful
+        if result:
+            ps = await self.__getProvisioningSessionCache(provisioning_session)
+            if ps is not None and ps['consumption-reporting-configuration'] is not None:
+                ps['consumption-reporting-configuration'] = None
+        return result
 
     async def consumptionReportingConfigurationDelete(self, provisioning_session: ResourceId) -> bool:
         '''Remove the `ConsumptionReportingConfiguration` for a provisioning session
@@ -500,7 +534,12 @@ class M1Session:
         if provisioning_session not in self.__provisioning_sessions:
             return False
         await self.__connect()
-        return await self.__m1_client.destroyConsumptionReportingConfiguration(provisioning_session)
+        result: bool = await self.__m1_client.destroyConsumptionReportingConfiguration(provisioning_session)
+        if result:
+            ps = await self.__getProvisioningSessionCache(provisioning_session)
+            if ps is not None and ps['consumption-reporting-configuration'] is not None:
+                ps['consumption-reporting-configuration'] = None
+        return result
 
     # PolicyTemplate methods
 
@@ -570,7 +609,13 @@ class M1Session:
         if provisioning_session_id not in self.__provisioning_sessions:
             return False
         await self.__connect()
-        return await self.__m1_client.updatePolicyTemplate(provisioning_session_id, policy_template_id, policy_template)
+        result: Optional[bool] = await self.__m1_client.updatePolicyTemplate(provisioning_session_id, policy_template_id, policy_template)
+        # Clear cache if update successful
+        if result is not None and result:
+            ps = await self.__getProvisioningSessionCache(provisioning_session)
+            if ps is not None and 'policyTemplates' in ps and ps['policyTemplates'] is not None and policy_template_id in ps['policyTemplates']:
+                del ps['policyTemplates'][policy_template_id]
+        return result
 
     async def policyTemplateDelete(self, provisioning_session_id: ResourceId, policy_template_id: ResourceId) -> bool:
         '''Delete a policy template
@@ -579,7 +624,12 @@ class M1Session:
         if provisioning_session_id not in self.__provisioning_sessions:
             return False
         await self.__connect()
-        return await self.__m1_client.destroyPolicyTemplate(provisioning_session_id, policy_template_id)
+        result: bool = await self.__m1_client.destroyPolicyTemplate(provisioning_session_id, policy_template_id)
+        if result:
+            ps = await self.__getProvisioningSessionCache(provisioning_session)
+            if ps is not None and 'policyTemplates' in ps and ps['policyTemplates'] is not None and policy_template_id in ps['policyTemplates']:
+                del ps['policyTemplates'][policy_template_id]
+        return result
     
     # Metrics Reporting Configuration methods
                
@@ -651,7 +701,13 @@ class M1Session:
         if provisioning_session_id not in self.__provisioning_sessions:
             return False
         await self.__connect()
-        return await self.__m1_client.updateMetricsReportingConfiguration(provisioning_session_id, metrics_reporting_configuration_id, metrics_reporting_configuration)
+        result: Optional[bool] = await self.__m1_client.updateMetricsReportingConfiguration(provisioning_session_id, metrics_reporting_configuration_id, metrics_reporting_configuration)
+        # Clear cache if update successful
+        if result is not None and result:
+            ps = await self.__getProvisioningSessionCache(provisioning_session_id)
+            if ps is not None and 'metricsReportingConfigurations' in ps and ps['metricsReportingConfigurations'] is not None and metrics_reporting_configuration_id in ps['metricsReportingConfigurations']:
+                del ps['metricsReportingConfigurations'][metrics_reporting_configuration_id]
+        return result
 
     async def metricsReportingConfigurationDelete(self, provisioning_session_id: ResourceId, metrics_reporting_configuration_id: ResourceId) -> bool:
         '''
@@ -660,8 +716,12 @@ class M1Session:
         if provisioning_session_id not in self.__provisioning_sessions:
             return False
         await self.__connect()
-        return await self.__m1_client.destroyMetricsReportingConfiguration(provisioning_session_id, metrics_reporting_configuration_id)
-
+        result: bool = await self.__m1_client.destroyMetricsReportingConfiguration(provisioning_session_id, metrics_reporting_configuration_id)
+        if result:
+            ps = await self.__getProvisioningSessionCache(provisioning_session_id)
+            if ps is not None and 'metricsReportingConfigurations' in ps and ps['metricsReportingConfigurations'] is not None and metrics_reporting_configuration_id in ps['metricsReportingConfigurations']:
+                del ps['metricsReportingConfigurations'][metrics_reporting_configuration_id]
+        return result
 
     # Convenience methods
 
@@ -828,10 +888,6 @@ class M1Session:
 
     async def __pathToContentType(self, path: str) -> str:
         self.__log.debug(f'__pathToContentType({path!r})')
-        type_map = {
-                'mpd': 'application/dash+xml',
-                'm3u8': 'application/vnd.apple.mpegurl',
-                }
         suffix = path.rsplit('.',1)[-1]
         if suffix in self.__file_suffix_to_mime:
             return self.__file_suffix_to_mime[suffix]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 
 [project]
 name = "rt-5gms-application-provider"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
     'httpx[http2] >= 0.21.1',
     'h11 >= 0.11.0',


### PR DESCRIPTION
@ErikGaida via slack on 24th September 2025:
> Hey David,
> I have a question about the Content Hosting Configuration (CHC).
> When I update the CHC with
> ```python
> await m1_session.contentHostingConfigurationUpdate(provisioning_session_id, chc)
> ```
> the AF is updated, I can see the new config in Postman but
> ```python
> await m1_session.contentHostingConfigurationGet(provisioning_session_id)
> ```
[returns the old version of the CHC]
> 
> For context, my GET endpoint is:
> ```python
> @app.get("/get_content_hosting_configuration/{provisioning_session_id}")
> async def get_content_hosting_configuration(provisioning_session_id: str, config = Depends(get_config)):
>     m1_session = await get_M1Session()
>     chc = await m1_session.contentHostingConfigurationGet(provisioning_session_id)
>     if chc is None:
>         raise HTTPException(status_code=404, detail="No CHC configuration found for this session")
>     result = chc.toJSON() if hasattr(chc, "toJSON") else (chc.__dict__ if hasattr(chc, "__dict__") else dict(chc))
>     return JSONResponse(content=result, status_code=200)
> ```
> And my SET/UPDATE endpoint:
> ```python
> @app.post("/set_content_hosting_configuration/{provisioning_session_id}")
> async def set_content_hosting_configuration(provisioning_session_id: str, request: Request, config = Depends(get_config)):
>     payload = await request.json()
>     m1_session = await get_M1Session()
>     chc = ContentHostingConfiguration(payload)
> 
>     exists = await m1_session.contentHostingConfigurationGet(provisioning_session_id)
>     if exists is None:
>         ok = await m1_session.contentHostingConfigurationCreate(provisioning_session_id, chc)
>         action = "created"
>     else:
>         ok = await m1_session.contentHostingConfigurationUpdate(provisioning_session_id, chc)
>         action = "updated"
>         # The following commented code "fixes" it by forcing a refresh,
>         # but it's not clean because it pokes into private internals:
>         # ps_map = getattr(m1_session, "_M1Session__provisioning_sessions", {})
>         # if provisioning_session_id in ps_map:
>         #     ps_map[provisioning_session_id]["content-hosting-configuration"] = None
>         #     ps_map[provisioning_session_id]["last-modified"] = datetime.now(timezone.utc).isoformat()
> 
>     if not ok:
>         raise HTTPException(status_code=500, detail="Operation failed")
> 
>     return JSONResponse(content={"message": f"CHC successfully {action} for session {provisioning_session_id}",
>                                  "contentHostingConfiguration": (chc.toJSON() if hasattr(chc, "toJSON") else payload)},
>                         status_code=200)
> ```
> The commented block above does resolve the issue (it forces a refresh), but it’s not a clean solution because it touches private attributes and doesn’t feel right.
> you can´t see updates with contentHostingConfigurationGet, you get only the first created CHC from the cache
> i also make it with, but we have the class M1Session and there is the logic for contentHostingConfigurationGet,
> this would be a solution to ask the af direct
> ```python
> @app.get("/get_content_hosting_configuration/{provisioning_session_id}")
> async def get_content_hosting_configuration(provisioning_session_id: str):
>     url = f"http://{app_configuration.get('m1_address','localhost')}:{app_configuration.get('m1_port',7777)}/3gpp-m1/v2/provisioning-sessions/{provisioning_session_id}/content-hosting-configuration"
>     async with httpx.AsyncClient() as client:
>         r = await client.get(url, headers={"Accept": "application/json"})
>     if r.status_code == 404:
>         raise HTTPException(status_code=404, detail="No CHC configuration found for this session")
>     r.raise_for_status()
>     return JSONResponse(content=r.json(), status_code=200)
> ```
> what do you think would be the cleanest way to solved?

This PR fixes the issue above, reported via slack.

Adjust `M1Session` methods for update and delete requests so that they purge the M1 client's object cache if the request is successful. This avoids the `M1Session` object returning stale results after an update or delete operation.

Also bumps the module version to 1.0.1 to indicate this bug fix and removes one piece of redundant code.