### PR TITLE
Fix metrics reporting configuration deletion crashes

### DIFF
--- a/management-ui/server.py
+++ b/management-ui/server.py
@@ -849,7 +849,21 @@ async def delete_metrics(provisioning_session_id: str, metrics_reporting_configu
         media_session = await media_configuration.mediaSessionByProvisioningSessionId(provisioning_session_id)
         if media_session is None:
             raise HTTPException(status_code=404, detail="Provisioning session not found")
-        metrics_removed = media_session.removeMetricsReportingConfiguration(metrics_reporting_configuration_id)
+
+        reporting_configurations = media_session.reporting_configurations
+        if reporting_configurations is None or reporting_configurations.metrics is None:
+            raise HTTPException(status_code=404, detail="MetricsReportingConfiguration not found")
+
+        metric_to_delete = None
+        for metric in reporting_configurations.metrics:
+            if metric.metrics_reporting_configuration_id == metrics_reporting_configuration_id:
+                metric_to_delete = metric
+                break
+
+        if metric_to_delete is None:
+            raise HTTPException(status_code=404, detail="MetricsReportingConfiguration not found")
+
+        metrics_removed = media_session.removeMetricsReportingConfiguration(metric_to_delete)
         if not metrics_removed:
             raise HTTPException(status_code=404, detail="MetricsReportingConfiguration not found or could not be deleted")
         await media_configuration.synchronise()
@@ -857,6 +871,7 @@ async def delete_metrics(provisioning_session_id: str, metrics_reporting_configu
     except HTTPException as e:
         raise e
     except Exception as e:
+        traceback.print_exception(e)
         raise HTTPException(
             status_code=500,
             detail=f"An error occurred while deleting metrics reporting configuration: {str(e)}"

--- a/python/lib/rt_m1_client/session.py
+++ b/python/lib/rt_m1_client/session.py
@@ -693,6 +693,11 @@ class M1Session:
                 if mrc_resp['MetricsReportingConfiguration'] is None:
                     mrc_resp['MetricsReportingConfiguration'] = ps['metricsReportingConfigurations'][mrc_id]['metricsreportingconfiguration']
                 ps['metricsReportingConfigurations'][mrc_id] = {k.lower(): v for k,v in mrc_resp.items()}
+            if 'provisioningsession' in ps and ps['provisioningsession'] is not None:
+                if 'metricsReportingConfigurationIds' not in ps['provisioningsession']:
+                    ps['provisioningsession']['metricsReportingConfigurationIds'] = []
+                if mrc_id not in ps['provisioningsession']['metricsReportingConfigurationIds']:
+                    ps['provisioningsession']['metricsReportingConfigurationIds'].append(mrc_id)
         return mrc_id
 
          
@@ -737,6 +742,11 @@ class M1Session:
             ps = await self.__getProvisioningSessionCache(provisioning_session_id)
             if ps is not None and 'metricsReportingConfigurations' in ps and ps['metricsReportingConfigurations'] is not None and metrics_reporting_configuration_id in ps['metricsReportingConfigurations']:
                 del ps['metricsReportingConfigurations'][metrics_reporting_configuration_id]
+            if ps is not None and 'provisioningsession' in ps and ps['provisioningsession'] is not None:
+                if 'metricsReportingConfigurationIds' in ps['provisioningsession']:
+                    id_list = ps['provisioningsession']['metricsReportingConfigurationIds']
+                    if id_list is not None and metrics_reporting_configuration_id in id_list:
+                        id_list.remove(metrics_reporting_configuration_id)
         return result
 
     # Convenience methods

--- a/python/lib/rt_media_configuration/delta_operations/media_metrics_reporting.py
+++ b/python/lib/rt_media_configuration/delta_operations/media_metrics_reporting.py
@@ -85,7 +85,12 @@ class MediaMetricsReportingDeltaOperation(DeltaOperation):
             if not await m1_session.metricsReportingConfigurationDelete(self.session.identity(), self.__mmrc_id):
                 return False
             if update_container:
-                self.session.removeMetricsReportingConfiguration(self.__mmrc_id)
+                rc = self.session.reporting_configurations
+                if rc is not None and rc.metrics is not None:
+                    for metric in rc.metrics:
+                        if metric.metrics_reporting_configuration_id == self.__mmrc_id:
+                            self.session.removeMetricsReportingConfiguration(metric)
+                            break
         return True
 
     @staticmethod

--- a/python/lib/rt_media_configuration/media_configuration.py
+++ b/python/lib/rt_media_configuration/media_configuration.py
@@ -345,8 +345,9 @@ configuration with the 5GMS AF.
                         else:
                             metric_to_del += [metric]
                     ret += [await MediaMetricsReportingDeltaOperation(session, add=metric) for metric in metric_to_add]
-                    ret += [await MediaMetricsReportingDeltaOperation(session, remove=metric) for metric in metric_to_del]
-                elif o_session.reporting_configurations is not None and o_session.reporting_configurations.metrics is not None:                         ret += [await MediaMetricsReportingDeltaOperation(session, add=metric) for metric in o_session.reporting_configurations.metrics]
+                    ret += [await MediaMetricsReportingDeltaOperation(session, remove=metric.metrics_reporting_configuration_id) for metric in metric_to_del]
+                elif o_session.reporting_configurations is not None and o_session.reporting_configurations.metrics is not None:
+                    ret += [await MediaMetricsReportingDeltaOperation(session, add=metric) for metric in o_session.reporting_configurations.metrics]
         return ret
 
     async def updateM8Files(self):


### PR DESCRIPTION
# Fix metrics reporting configuration deletion crashes

Closes #93

## Summary

Fixes three related bugs that caused metrics reporting configuration 
deletion to crash or behave incorrectly. 
See #93 for full details including tracebacks and root cause analysis.
