### PR TITLE
Bugfix/m8 outputs

### DIFF
--- a/management-ui/server.py
+++ b/management-ui/server.py
@@ -62,12 +62,24 @@ def _load_media_config_from_configuration():
 async def load_media_config():
     global _media_config
     _media_config = _load_media_config_from_configuration()
-    app.mount("/m8_dir", StaticFiles(directory = _media_config.get("root_dir", ""), check_dir=False), name="m8_dir")
+
+def _global_m8_file_path() -> str:
+    root_dir = _media_config.get("root_dir", "") if _media_config else ""
+    filename = _media_config.get("m8_json_filename", "m8.json") if _media_config else "m8.json"
+    return os.path.join(root_dir, filename)
 
 @app.get("/show_config")
 async def get_m8():
     return _media_config
 
+@app.get("/m8.json")
+async def m8_file_get():
+    if _media_config is None:
+        raise HTTPException(status_code=500, detail="Media configuration not loaded")
+    m8_file = _global_m8_file_path()
+    if not os.path.isfile(m8_file):
+        raise HTTPException(status_code=404, detail=f"Configured M8 JSON not found: {m8_file}")
+    return FileResponse(m8_file)
 
 app.add_middleware(
     CORSMiddleware,

--- a/management-ui/src/provisioning-interface.js
+++ b/management-ui/src/provisioning-interface.js
@@ -231,7 +231,13 @@ async function deleteSelectedSessions() {
 
 
 async function openM8() {
-    window.open(`${operatingUrl}m8_dir/m8.json`)
+  try {
+    const url = `${operatingUrl}m8.json`;
+    window.open(url);
+  } catch (e) {
+    console.error(e);
+    notifyError('Could not open M8 JSON.');
+  }
 }
 
 async function addSessionToTable(sessionId) {

--- a/python/lib/rt_m8_output/five_g_mag_json.py
+++ b/python/lib/rt_m8_output/five_g_mag_json.py
@@ -36,7 +36,7 @@ import aiofiles
 import json
 import os
 import os.path
-
+from typing import Optional
 from rt_m1_client import Configuration, app_configuration
 from rt_media_configuration import MediaConfiguration
 from .m8_output import M8Output
@@ -47,10 +47,17 @@ class FiveGMagJsonFormatter(M8Output):
 ===========================
 Output formatter to represent a MediaConfiguration as a 5G-MAG m8.json file
 '''
-    def __init__(self, root_dir: str, m8_json_filename: str = 'm8.json', config: Configuration = app_configuration):
+    def __init__(self, root_dir: Optional[str] = None, m8_json_filename: Optional[str] = None, config: Configuration = app_configuration, m5_authority: Optional[str] = None):
+        self.__config = config
+        if root_dir is None:
+            root_dir = self.__config.get('root_dir', section='media-configuration', default='.')
+        if m8_json_filename is None:
+            m8_json_filename = self.__config.get('m8_json_filename', section='media-configuration', default='m8.json')
+        if m5_authority is None:
+            m5_authority = self.__config.get("m5_authority", section="media-configuration", default="localhost")
         super().__init__(root_dir)
         self.__json_filename = m8_json_filename
-        self.__config = config
+        self.__m5_authority = m5_authority
 
     async def writeOutput(self, media_config: MediaConfiguration):
         '''Write out the 5G-MAG m8.json file
@@ -58,7 +65,7 @@ Output formatter to represent a MediaConfiguration as a 5G-MAG m8.json file
         if not os.path.isdir(self.root_dir):
             os.makedirs(self.root_dir, mode=0o755)
         async with aiofiles.open(os.path.join(self.root_dir, self.__json_filename), mode='w') as json_out:
-            m8_config = {'m5BaseUrl': f'http://{self.__config.get("m5_authority", section="media-configuration", default="localhost")}/3gpp-m5/v2/', 'serviceList': []}
+            m8_config = {'m5BaseUrl': f'http://{self.__m5_authority}/3gpp-m5/v2/', 'serviceList': []}
             for session in await media_config.mediaSessions():
                 me = session.media_entry
                 if me is None or session.provisioning_session_id is None:

--- a/python/lib/rt_m8_output/five_g_mag_json.py
+++ b/python/lib/rt_m8_output/five_g_mag_json.py
@@ -50,11 +50,11 @@ Output formatter to represent a MediaConfiguration as a 5G-MAG m8.json file
     def __init__(self, root_dir: Optional[str] = None, m8_json_filename: Optional[str] = None, config: Configuration = app_configuration, m5_authority: Optional[str] = None):
         self.__config = config
         if root_dir is None:
-            root_dir = self.__config.get('root_dir', section='media-configuration', default='.')
+            root_dir = self.__config.get('root_dir', section='media-configuration', default='/usr/share/nginx/html/m8')
         if m8_json_filename is None:
             m8_json_filename = self.__config.get('m8_json_filename', section='media-configuration', default='m8.json')
         if m5_authority is None:
-            m5_authority = self.__config.get("m5_authority", section="media-configuration", default="localhost")
+            m5_authority = self.__config.get("m5_authority", section="media-configuration", default="localhost:7777")
         super().__init__(root_dir)
         self.__json_filename = m8_json_filename
         self.__m5_authority = m5_authority

--- a/python/lib/rt_media_configuration/media_configuration.py
+++ b/python/lib/rt_media_configuration/media_configuration.py
@@ -56,9 +56,9 @@ from .importers import M1SessionImporter
 #: :private:
 DEFAULT_CONFIG = '''[media-configuration]
 m5_authority = localhost:7777
-format = FiveGMagJsonFormatter
 root_dir = /usr/share/nginx/html/m8
-m8outputs = %(format)s(root_dir=%(root_dir)s)
+m8_json_filename = m8.json
+m8outputs = FiveGMagJsonFormatter()
 '''
 
 class MediaConfiguration:
@@ -365,8 +365,11 @@ configuration with the 5GMS AF.
         :meta private:
         :return: self
         '''
-        m8_outputs: List[str] = self.__config.get('m8outputs', section='media-configuration', default='').split(',')
+        m8_outputs: List[str] = self.__config.get('m8outputs', section='media-configuration', default='').split(';')
         for outstr in m8_outputs:
+            outstr = outstr.strip()
+            if outstr == '':
+                continue
             m8_out = await self.__make_m8_output(outstr)
             await m8_out.addToMediaConfiguration(self)
         return self
@@ -386,6 +389,7 @@ configuration with the 5GMS AF.
 
     async def __make_m8_output(self, outstr: str) -> "M8Output":
         from rt_m8_output import M8Output
+        outstr = ''.join(outstr.split())
         match = self.__fnstr_re.match(outstr)
         if match is None:
             raise ValueError(f'Badly formatted M8Output name: {outstr}')

--- a/python/lib/rt_media_configuration/media_configuration.py
+++ b/python/lib/rt_media_configuration/media_configuration.py
@@ -366,11 +366,23 @@ configuration with the 5GMS AF.
         :return: self
         '''
         m8_outputs: List[str] = self.__config.get('m8outputs', section='media-configuration', default='').split(';')
+        has_default_fivegmag_formatter = False
         for outstr in m8_outputs:
             outstr = outstr.strip()
             if outstr == '':
                 continue
+
+            check = ''.join(outstr.split())
+            match = self.__fnstr_re.match(check)
+            if match is not None:
+                name, args, kwargs = match.group('name', 'args', 'kwargs')
+                if name == 'FiveGMagJsonFormatter' and args is None and kwargs is None:
+                    has_default_fivegmag_formatter = True
             m8_out = await self.__make_m8_output(outstr)
+            await m8_out.addToMediaConfiguration(self)
+
+        if not has_default_fivegmag_formatter:
+            m8_out = await self.__make_m8_output('FiveGMagJsonFormatter()')
             await m8_out.addToMediaConfiguration(self)
         return self
 


### PR DESCRIPTION
# Summary

## 1. Bugfix: `ValueError` when parsing multiple `m8outputs`

When multiple formatter definitions were configured, parsing could fail with:

```
application-provider-1  |     raise ValueError(f'Badly formatted M8Output name: {outstr}')
application-provider-1  | ValueError: Badly formatted M8Output name: FiveGMagJsonFormatter(root_dir=/usr/share/nginx/html/m8/test
```

## Root cause
The m8outputs value was split by comma:
`m8_outputs: List[str] = self.__config.get('m8outputs', section='media-configuration', default='').split(',')`
Because commas are also used between formatter and arguments, an entry like:
`m8outputs = FiveGMagJsonFormatter(root_dir=/usr/share/nginx/html/m8/test,m8_json_filename="test_m8_output.json")`
was incorrectly cut to:
`FiveGMagJsonFormatter(root_dir=/usr/share/nginx/html/m8/test`
which then triggered the ValueError.
## Fix
m8outputs now uses semicolons (;) to separate formatter instances, while commas (,) remain the separator for arguments inside each formatter.
Valid format (multiple outputs)
`m8outputs = FiveGMagJsonFormatter(argument,argument,argument);FiveGMagJsonFormatter(argument,argument,argument)`
Example
`m8outputs = FiveGMagJsonFormatter(root_dir=/usr/share/nginx/html/m8/1,m8_json_filename=real_m8_output.json,m5_authority=1);FiveGMagJsonFormatter(root_dir=/usr/share/nginx/html/m8/2,m8_json_filename=test_m8_output.json,m5_authority=2)`

## 2. Enhancement: `FiveGMagJsonFormatter` configuration and overrides

`FiveGMagJsonFormatter` now supports both:

1. loading defaults from `media.conf`, and  
2. overriding individual values via formatter arguments.

### Default configuration

```
[media-configuration]
m5_authority = localhost:7777
root_dir = /usr/share/nginx/html/m8
m8_json_filename = m8.json
m8outputs = FiveGMagJsonFormatter()
```
### Behavior without arguments
If FiveGMagJsonFormatter() is used without arguments, it reads:

m5_authority from media.conf
root_dir from media.conf
m8_json_filename from media.conf

### Supported overrides
You can override any of these values per formatter instance:

- root_dir
- m8_json_filename
- m5_authority

#### Example 1: override only root_dir

`m8outputs = FiveGMagJsonFormatter(root_dir=/usr/share/nginx/html/m8/test)`


##### Result:

- Output directory: /usr/share/nginx/html/m8/test
- File name: m8.json (from media.conf)
- m5_authority: localhost:7777 (from media.conf)

#### Example 2: override all values
`m8outputs = FiveGMagJsonFormatter(root_dir=/usr/share/nginx/html/m8/test,m8_json_filename=test_m8_output.json,m5_authority=192.168.1.10:7778)`

###### Result:

- Output directory: /usr/share/nginx/html/m8/test
- File name: test_m8_output.json
- m5_authority: 192.168.1.10:7778

## 3. M8 file is now available at `http://localhost:8000/m8.json`

The Management UI now serves the M8 output through a fixed endpoint:

- `GET /m8.json`

The file returned by this endpoint is resolved from `media.conf` using:

- `root_dir`
- `m8_json_filename`

### Important requirement

`m8outputs` must include a default `FiveGMagJsonFormatter()` entry, for example:


`m8outputs = FiveGMagJsonFormatter()`

Reason:

- The /m8.json endpoint returns the file referenced by the global default values (root_dir + m8_json_filename).
- If no default FiveGMagJsonFormatter() is configured to generate that file, the UI button cannot open m8.json (file not found).
